### PR TITLE
Include ts and tsx ext checking

### DIFF
--- a/findLoader.js
+++ b/findLoader.js
@@ -11,7 +11,8 @@ module.exports = (webpackConfig, reactAppSrcDir) => {
                 return false;
             }
 
-            if (!loader.test.toString().includes('(js|mjs|jsx)')) {
+            const loaderTest = loader.test.toString();
+            if (!['js', 'mjs', 'jsx', 'ts', 'tsx'].every(ext => loaderTest.includes(ext))) {
                 return false;
             }
 


### PR DESCRIPTION
Plugin does not support CRA with TS yet. 
This PR fixed it.

I fixed thing in your comment at [PR1](https://github.com/F1LT3R/babel-loader-lerna-cra/pull/2) and now we are checking array of ext.